### PR TITLE
feat: add option of padding in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,10 @@ require('cokeline').setup({
   sidebar = {
     filetype = '<filetype>',
     components = {..},
+
+    -- Add additional padding to the component.
+    -- default: `0`
+    padding = int,
   },
 })
 ```

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -112,6 +112,10 @@ The valid keys are:
     sidebar = {
       filetype = '<filetype>',
       components = {..},
+
+      -- Add additional padding to the component.
+      -- default: `0`
+      padding = int,
     },
   })
 <

--- a/lua/cokeline/sidebar.lua
+++ b/lua/cokeline/sidebar.lua
@@ -81,7 +81,8 @@ local get_components = function()
     components.shorten(sidebar_components, sidebar_width)
     sort(sidebar_components, rendering.by_decreasing_index)
   elseif width < sidebar_width then
-    local space_left = sidebar_width - width
+    local padding = _G.cokeline.config.sidebar.padding or 0
+    local space_left = sidebar_width - width + padding
     local last = #sidebar_components
     sidebar_components[last].text = sidebar_components[last].text
       .. rep(" ", space_left)


### PR DESCRIPTION
Hi! First of all, I'm so happy and excited to know this awesome plugin.

I like `cokeline` sidebar feature. but, one thing, I wish there was an option to further customize the UI.

For example:
![화면 캡처 2022-04-04 213200](https://user-images.githubusercontent.com/32578710/161547115-36a922bd-de46-4d44-8a67-11589d8037cb.png)

It would be nice if we could adjust the length of the entire width of the component like this.
![화면 캡처 2022-04-04 213140](https://user-images.githubusercontent.com/32578710/161547283-ea65df6f-4795-4eb4-a554-42e130a4cdbb.png)

So I simply added a padding option. Please let me know if there is anything I missed or need to be corrected 😸 

