### PR TITLE
fix: check for Windows always fails when computing `unique_prefix`

### DIFF
--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -49,7 +49,7 @@ Buffer.__index = Buffer
 ---@param buffers  Buffer[]
 ---@return Buffer[]
 local compute_unique_prefixes = function(buffers)
-  local is_windows = not fn.has("win32") == 0
+  local is_windows = fn.has("win32") == 1
 
   -- FIXME: it appears in windows sometimes directories are separated by '/'
   -- instead of '\\'??


### PR DESCRIPTION
`not fn.has("win32") == 0` is always `false` even on Windows, as:
- `fn.has("win32")` returns `1` or `0`
- both `not 1` and `not 0` evaluate to `false` as [numbers always evaluate to true in lua](https://github.com/nanotee/nvim-lua-guide#caveats-4)
- `false == 0` is always `false`

Basically it would needs braces but it can also have this simple form: 
```lua
fn.has("win32") == 1
```

So it seems like its broken on Windows since 9fd956fc3f9550052acbc4451ec3e3020ffab983 (v0.1.0), possibly during refactor.