### PR TITLE
Adding is_last and is_first to buffer return

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,3 +1421,158 @@ require("cokeline").setup(
 
 ![cokeline-danielnieto89](https://user-images.githubusercontent.com/2120107/171753414-9d81c866-7f99-48f8-b6ff-0c28e8883aaa.gif)
 
+### author: [@miversen33](https://github.com/miversen33)
+
+<details>
+<summary>This configuration shows the `is_first` and `is_last` buffer options and how to create a cokeline with different components based on if the
+component is the first, last, or neither Additionally, this config has some integration with the lsp.</summary>
+
+```lua
+local get_hex = require("cokeline.utils").get_hex
+local active_bg_color = '#931E9E'
+local inactive_bg_color = get_hex('Normal', 'bg')
+local bg_color = get_hex('ColorColumn', 'bg')
+require('cokeline').setup({
+      show_if_buffers_are_at_least = 1,
+      mappings = {
+          cycle_prev_next = true
+      },
+      default_hl = {
+        bg = function(buffer)
+          if buffer.is_focused then
+            return active_bg_color
+          end
+        end,
+      },
+      components = {
+          {
+            text = function(buffer)
+              local _text = ''
+              if buffer.index > 1 then _text = ' ' end
+              if buffer.is_focused or buffer.is_first then
+                _text = _text .. ''
+              end
+              return _text
+            end,
+            fg = function(buffer)
+              if buffer.is_focused then
+                return active_bg_color
+              elseif buffer.is_first then
+                return inactive_bg_color
+              end
+            end,
+            bg = function(buffer)
+              if buffer.is_focused then
+                if buffer.is_first then
+                  return bg_color
+                else
+                  return inactive_bg_color
+                end
+              elseif buffer.is_first then
+                  return bg_color
+              end
+            end
+          },
+          {
+              text = function(buffer)
+                  local status = ''
+                  if buffer.is_readonly then
+                      status = '➖'
+                  elseif buffer.is_modified then
+                      status = ''
+                  end
+                  return status
+              end,
+          },
+          {
+              text = function(buffer)
+                  return " " .. buffer.devicon.icon
+              end,
+              fg = function(buffer)
+                if buffer.is_focused then
+                  return buffer.devicon.color
+                end
+              end
+          },
+          {
+              text = function(buffer)
+                return buffer.unique_prefix .. buffer.filename
+              end,
+              fg = function(buffer)
+                  if(buffer.diagnostics.errors > 0) then
+                      return '#C95157'
+                  end
+              end,
+              style = function(buffer)
+                  local text_style = 'NONE'
+                  if buffer.is_focused then
+                      text_style = 'bold'
+                  end
+                  if buffer.diagnostics.errors > 0 then
+                      if text_style ~= 'NONE' then
+                          text_style = text_style .. ',underline'
+                      else
+                          text_style = 'underline'
+                      end
+                  end
+                  return text_style
+              end
+          },
+          {
+              text = function(buffer)
+                  local errors = buffer.diagnostics.errors
+                  if(errors <= 9) then
+                      errors = ''
+                  else
+                      errors = "🙃"
+                  end
+                  return errors .. ' '
+              end,
+              fg = function(buffer)
+                if buffer.diagnostics.errors == 0 then
+                  return '#3DEB63'
+                elseif buffer.diagnostics.errors <= 9 then
+                  return '#DB121B'
+                end
+              end
+          },
+          {
+              text = '',
+              delete_buffer_on_left_click = true
+          },
+          {
+            text = function(buffer)
+              if buffer.is_focused or buffer.is_last then
+                return ''
+              else
+                return ' '
+              end
+            end,
+            fg = function(buffer)
+              if buffer.is_focused then
+                return active_bg_color
+              elseif buffer.is_last then
+                return inactive_bg_color
+              else
+                return bg_color
+              end
+            end,
+            bg = function(buffer)
+              if buffer.is_focused then
+                if buffer.is_last then
+                  return bg_color
+                else
+                  return inactive_bg_color
+                end
+              elseif buffer.is_last then
+                  return bg_color
+              end
+            end
+          }
+      },
+  })
+```
+</details>
+
+![cokeline-miversen33](https://user-images.githubusercontent.com/2640668/174489433-2faa0eea-4921-42ea-a877-1e143e44bc14.png)
+

--- a/README.md
+++ b/README.md
@@ -541,6 +541,12 @@ buffer = {
 
   is_readonly = true | false,
 
+  -- The buffer is the first visible buffer in the tab bar
+  is_first    = true | false,
+  
+  -- The buffer is the last visible buffer in the tab bar
+  is_last     = true | false,
+
   -- The buffer's type as reported by `:echo &buftype`.
   type = 'string',
 

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -140,6 +140,12 @@ The `buffer` parameter is just a Lua table with the following keys:
 
     is_readonly = bool,
 
+    -- The buffer is the first visible buffer in the tab bar
+    is_first    = true | false,
+
+    -- The buffer is the last visible buffer in the tab bar
+    is_last     = true | false,
+
     -- The buffer's type as reported by `:echo &buftype`.
     type = 'string',
 

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -200,6 +200,8 @@ Buffer.new = function(b)
     number = b.bufnr,
     type = opts.buftype,
     is_focused = (b.bufnr == fn.bufnr("%")),
+    is_first = false,
+    is_last = false,
     is_modified = opts.modified,
     is_readonly = opts.readonly,
     path = b.name,
@@ -336,6 +338,11 @@ local get_visible_buffers = function()
       _G.cokeline.config.buffers.filter_visible,
       _G.cokeline.valid_buffers
     )
+
+  if #_G.cokeline.visible_buffers > 0 then
+    _G.cokeline.visible_buffers[1].is_first = true
+    _G.cokeline.visible_buffers[#_G.cokeline.visible_buffers].is_last = true
+  end
 
   for i, buffer in ipairs(_G.cokeline.visible_buffers) do
     buffer.index = i


### PR DESCRIPTION
Essentially the same concept as [PR 54](https://github.com/noib3/nvim-cokeline/pull/54), though I didn't include the later about exposing all buffers.

Adding the `is_first` and `is_last` buffer options allows configurations such as this
![image](https://user-images.githubusercontent.com/2640668/174464628-f942d9a3-1058-432b-a3ab-bdea7ffef976.png)
Where the first and last buffer have different left and right icons depending on if they are the first/last or not