### PR TITLE
feat: `pick.use_filename` and `pick.letters` config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,19 @@ require('cokeline').setup({
     max_buffer_width = int,
   },
 
+  pick = {
+    -- Whether to use the filename's first letter first before
+    -- picking a letter from the valid letters list in order.
+    -- default: `true`
+    use_filename = true | false,
+
+    -- The list of letters that are valid as pick letters. Sorted by
+    -- keyboard reachability by default, but may require tweaking for
+    -- non-QWERTY keyboard layouts.
+    -- default: `'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP'`
+    letters = 'string',
+  },
+
   -- The default highlight group values.
   -- The `fg` and `bg` keys are either colors in hexadecimal format or
   -- functions taking a `buffer` parameter and returning a color in

--- a/doc/cokeline.txt
+++ b/doc/cokeline.txt
@@ -61,6 +61,19 @@ The valid keys are:
       new_buffers_position = 'last' | 'next',
     },
 
+    pick = {
+      -- Whether to use the filename's first letter first before
+      -- picking a letter from the valid letters list in order.
+      -- default: `true`
+      use_filename = true | false,
+
+      -- The list of letters that are valid as pick letters. Sorted by
+      -- keyboard reachability by default, but may require tweaking for
+      -- non-QWERTY keyboard layouts.
+      -- default: `'asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERTYQP'`
+      letters = 'string',
+    },
+
     mappings = {
       -- Controls what happens when the first (last) buffer is focused and you
       -- try to focus/switch the previous (next) buffer. If `true` the last

--- a/lua/cokeline/buffers.lua
+++ b/lua/cokeline/buffers.lua
@@ -17,8 +17,7 @@ local order = {}
 ---@type bufnr
 local current_valid_index
 
-local valid_pick_letters =
-  "asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP"
+local valid_pick_letters = false
 
 local taken_pick_letters = {}
 
@@ -100,18 +99,25 @@ end
 ---@param bufnr  bufnr
 ---@return string
 local get_pick_letter = function(filename, bufnr)
+  -- Initialize the valid letters string, if not already initialized
+  if not valid_pick_letters then
+    valid_pick_letters = _G.cokeline.config.pick.letters
+  end
+
   -- If the bufnr has already a letter associated to it return that.
   if taken_pick_letters[bufnr] then
     return taken_pick_letters[bufnr]
   end
 
-  -- If the initial letter of the filename is valid and it hasn't already been
-  -- assigned return that.
-  local init_letter = filename:sub(1, 1)
-  if valid_pick_letters:find(init_letter, nil, true) then
-    valid_pick_letters = valid_pick_letters:gsub(init_letter, "")
-    taken_pick_letters[bufnr] = init_letter
-    return init_letter
+  -- If the config option pick.use_filename is true, and the initial letter
+  -- of the filename is valid and it hasn't already been assigned return that.
+  if _G.cokeline.config.pick.use_filename then
+    local init_letter = filename:sub(1, 1)
+    if valid_pick_letters:find(init_letter, nil, true) then
+      valid_pick_letters = valid_pick_letters:gsub(init_letter, "")
+      taken_pick_letters[bufnr] = init_letter
+      return init_letter
+    end
   end
 
   -- Return the first valid letter if there is one.

--- a/lua/cokeline/config.lua
+++ b/lua/cokeline/config.lua
@@ -26,6 +26,11 @@ local defaults = {
     slider = sliders.center_current_buffer,
   },
 
+  pick = {
+    use_filename = true,
+    letters = "asdfjkl;ghnmxcvbziowerutyqpASDFJKLGHNMXCVBZIOWERUTYQP",
+  },
+
   ---@type table<string, any>
   default_hl = {
     fg = function(buffer)


### PR DESCRIPTION
This adds two config options: `pick.use_filename`, which lets you skip getting the pick letter from the filename, and `pick.letters`, which lets you change the order of letters used, for non-QWERTY layouts.

Closes #87.